### PR TITLE
ci: try to trigger pr merge to do integration testing

### DIFF
--- a/.github/workflows/test-go-unit.yml
+++ b/.github/workflows/test-go-unit.yml
@@ -68,7 +68,7 @@ jobs:
 
   acceptance_test:
     needs: unit_test
-    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+    if: github.event.pull_request.merged
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Why need this change? / Root cause:
- Try to fix the acceptance test when pr merge

## Changes made:
- Only use github.event.pull_request.merged as the judgment standard

## Test Scope / Change impact:

