### PR TITLE
ci: run unit tests on new Pull Requests and integration tests after merging

### DIFF
--- a/.github/workflows/test-go-unit.yml
+++ b/.github/workflows/test-go-unit.yml
@@ -82,6 +82,10 @@ jobs:
         working-directory: ./Backend
         run: cp env .env
 
+      - name: try
+        working-directory: ./Backend
+        run: cat .env
+
       - name: Migration
         working-directory: ./Backend
         run: go run ./cmd/migrate/migrate.go


### PR DESCRIPTION
## Why need this change? / Root cause:
- Try to fix the acceptance test when pr merge

## Changes made:
- Only use github.event.pull_request.merged as the judgment standard

## Test Scope / Change impact:

