### PR TITLE
ci: run unit tests on new Pull Requests and integration tests after merging

### DIFF
--- a/.github/workflows/test-go-unit.yml
+++ b/.github/workflows/test-go-unit.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: try
         working-directory: ./Backend
-        run: cat .env
+        run: echo ${{ secrets.DB_DATABASE }}
 
       - name: Migration
         working-directory: ./Backend


### PR DESCRIPTION
## Why need this change? / Root cause:
- Try to fix the acceptance test when pr merge

## Changes made:
- Only use github.event.pull_request.merged as the judgment standard

## Test Scope / Change impact:

